### PR TITLE
Refactor key transformations

### DIFF
--- a/introspective_grape.gemspec
+++ b/introspective_grape.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0'
 
-  s.add_dependency "rails", '>= 3.0.0' 
+  s.add_dependency "rails", '>= 3.0.0'
 
   s.add_dependency 'grape'          #, '~> 0.16.2'
   s.add_dependency 'grape-entity'   #, '< 0.5.0'
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '< 1.0' # There's a version 1.0.0 out there that breaks everything
   s.add_dependency 'grape-kaminari'
   s.add_dependency 'pundit'
-  s.add_dependency 'camel_snake_keys'
+  s.add_dependency 'activesupport', '> 4.1.8' # need #deep_transform_keys
 
   if RUBY_PLATFORM == 'java'
     #s.add_development_dependency "jdbc-sqlite3"

--- a/introspective_grape.gemspec
+++ b/introspective_grape.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '< 1.0' # There's a version 1.0.0 out there that breaks everything
   s.add_dependency 'grape-kaminari'
   s.add_dependency 'pundit'
-  s.add_dependency 'activesupport', '> 4.1.8' # need #deep_transform_keys
 
   if RUBY_PLATFORM == 'java'
     #s.add_development_dependency "jdbc-sqlite3"

--- a/lib/introspective_grape.rb
+++ b/lib/introspective_grape.rb
@@ -12,6 +12,10 @@ module IntrospectiveGrape
     autoload :CamelJson, 'introspective_grape/formatter/camel_json'
   end
 
+  module Utils
+    autoload :KeyTransformations, 'introspective_grape/utils/key_transformations'
+  end
+
   def self.config
     @config = OpenStruct.new(camelize_parameters: true)
   end

--- a/lib/introspective_grape.rb
+++ b/lib/introspective_grape.rb
@@ -14,6 +14,7 @@ module IntrospectiveGrape
 
   module Utils
     autoload :KeyTransformations, 'introspective_grape/utils/key_transformations'
+    autoload :JsonExpander,       'introspective_grape/utils/json_expander'
   end
 
   def self.config

--- a/lib/introspective_grape/camel_snake.rb
+++ b/lib/introspective_grape/camel_snake.rb
@@ -1,10 +1,11 @@
 require 'grape-swagger'
-require 'active_support' #/core_ext/module/aliasing'
-require 'camel_snake_keys'
-if IntrospectiveGrape.config.camelize_parameters 
+require 'active_support/core_ext/module/aliasing'
+require_relative 'utils/key_transformations'
+
+if IntrospectiveGrape.config.camelize_parameters
   # Camelize the parameters in the swagger documentation.
   if Gem::Version.new( GrapeSwagger::VERSION ) <= Gem::Version.new('0.11.0')
-    Grape::API.class_eval do 
+    Grape::API.class_eval do
       class << self
         private
         def create_documentation_class_with_camelized
@@ -14,9 +15,9 @@ if IntrospectiveGrape.config.camelize_parameters
               def parse_params_with_camelized(params, path, method, _options = {})
                 parsed_params = parse_params_without_camelized(params, path, method)
                 parsed_params.each_with_index do |param|
-                  param[:name] = param[:name]
-                                 .camelize(:lower)
-                                 .gsub(/Destroy/,'_destroy')
+                  param[:name] = IntrospectiveGrape::Utils::KeyTransformations.camelize(param[:name]).
+                    gsub(/Destroy/,'_destroy')
+
                 end
                 parsed_params
               end
@@ -40,7 +41,8 @@ if IntrospectiveGrape.config.camelize_parameters
           class << self
             def call_with_camelized(*args)
               param = call_without_camelized(*args)
-              param[:name] = param[:name].camelize(:lower).gsub(/Destroy/, '_destroy')
+              param[:name] = IntrospectiveGrape::Utils::KeyTransformations.camelize(param[:name]).
+                gsub(/Destroy/, '_destroy')
               param
             end
             alias_method_chain :call, :camelized

--- a/lib/introspective_grape/formatter/camel_json.rb
+++ b/lib/introspective_grape/formatter/camel_json.rb
@@ -1,19 +1,15 @@
 # Add a formatter to grape that converts all snake case hash keys from ruby to camel case.
-require 'camel_snake_keys'
+# require 'camel_snake_keys'
 require 'grape/formatter/json'
+require_relative '../utils/key_transformations'
+require_relative '../utils/json_expander'
+
 module IntrospectiveGrape
   module Formatter
     module CamelJson
       def self.call(object, _env)
-        if object.respond_to?(:to_json) && !object.respond_to?(:with_camel_keys) &&
-          (parsed_object = JSON.parse(object.to_json)).respond_to?(:with_camel_keys)
-          object = parsed_object
-				elsif object.kind_of?(Array) && object.first.kind_of?(Grape::Entity)
-        	# Force arrays of Grape::Entities into their hash representations before camelizing
-        	object = JSON.parse(object.to_json) 
-        end
-        object = object.with_camel_keys if object.respond_to?(:with_camel_keys)
-
+        object = IntrospectiveGrape::Utils::JsonExpander.expand(object)
+        object = IntrospectiveGrape::Utils::KeyTransformations.camel_keys(object)
         Grape::Formatter::Json.call(object, _env)
       end
     end

--- a/lib/introspective_grape/snake_params.rb
+++ b/lib/introspective_grape/snake_params.rb
@@ -1,3 +1,4 @@
+require_relative 'utils/key_transformations'
 module IntrospectiveGrape
   module SnakeParams
     def snake_params_before_validation
@@ -5,8 +6,8 @@ module IntrospectiveGrape
         # We have to snake case the Rack params then re-assign @params to the
         # request.params, because of the I-think-very-goofy-and-inexplicable
         # way Grape interacts with both independently of each other
-        (params.try(:with_snake_keys)||{}).each do |k,v|
-          request.delete_param(k.camelize(:lower))
+        (Utils::KeyTransformations.snake_keys(params)||{}).each do |k,v|
+          request.delete_param(Utils::KeyTransformations.camelize(k))
           request.update_param(k, v)
         end
         @params = request.params

--- a/lib/introspective_grape/utils/json_expander.rb
+++ b/lib/introspective_grape/utils/json_expander.rb
@@ -1,0 +1,21 @@
+module IntrospectiveGrape
+  module Utils
+    module JsonExpander
+      extend self
+
+      # Expands an object with its #to_json method if it's not a primitive or if the first element is a Grape::Entity.
+      def expand(object)
+        if (object.respond_to?(:to_json) &&
+          [String, Symbol, Hash, Array, NilClass, TrueClass, FalseClass, Numeric].all? { |x| !object.is_a?(x) }) ||
+          # Force arrays of Grape::Entities into their hash representations before camelizing
+          (object.is_a?(Array) && defined?(Grape::Entity) && object.first.is_a?(Grape::Entity))
+
+          JSON.parse(object.to_json)
+        else
+          object
+        end
+      end
+
+    end
+  end
+end

--- a/lib/introspective_grape/utils/key_transformations.rb
+++ b/lib/introspective_grape/utils/key_transformations.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/hash/keys' # for _deep_transform_keys_in_object
 require 'active_support/inflector/methods'
 module IntrospectiveGrape
   module Utils
@@ -15,12 +14,32 @@ module IntrospectiveGrape
 
       # Converts all the keys to camelcase with lowercase first letter.
       def camel_keys(data)
-        {}.send(:_deep_transform_keys_in_object, data) { |key| camelize(key) }
+        _deep_transform_keys_in_object(data) { |key| camelize(key) }
       end
 
       # Converts all the keys to snakecase.
       def snake_keys(data)
-        {}.send(:_deep_transform_keys_in_object, data) { |key| snakeize(key) }
+        _deep_transform_keys_in_object(data) { |key| snakeize(key) }
+      end
+
+      private
+
+      # Copied from 'active_support/core_ext/hash/keys' ( > 4.1.8) so that a) we don't have to extend Hash and b)
+      # to be able to access the function directly instead of needing to do
+      # {}.send(:_deep_transform_keys_in_object, data)
+      #
+      # support methods for deep transforming nested hashes and arrays
+      def _deep_transform_keys_in_object(object, &block)
+        case object
+        when Hash
+          object.each_with_object({}) do |(key, value), result|
+            result[yield(key)] = _deep_transform_keys_in_object(value, &block)
+          end
+        when Array
+          object.map {|e| _deep_transform_keys_in_object(e, &block) }
+        else
+          object
+        end
       end
 
     end

--- a/lib/introspective_grape/utils/key_transformations.rb
+++ b/lib/introspective_grape/utils/key_transformations.rb
@@ -1,0 +1,28 @@
+require 'active_support/core_ext/hash/keys' # for _deep_transform_keys_in_object
+require 'active_support/inflector/methods'
+module IntrospectiveGrape
+  module Utils
+    module KeyTransformations
+      extend self
+
+      def camelize(key)
+        (key.is_a?(String) || key.is_a?(Symbol)) ? ActiveSupport::Inflector.camelize(key.to_s, false) : key
+      end
+
+      def snakeize(key)
+        (key.is_a?(String) || key.is_a?(Symbol)) ? ActiveSupport::Inflector.underscore(key.to_s) : key
+      end
+
+      # Converts all the keys to camelcase with lowercase first letter.
+      def camel_keys(data)
+        {}.send(:_deep_transform_keys_in_object, data) { |key| camelize(key) }
+      end
+
+      # Converts all the keys to snakecase.
+      def snake_keys(data)
+        {}.send(:_deep_transform_keys_in_object, data) { |key| snakeize(key) }
+      end
+
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,20 +1,38 @@
-require 'introspective_grape/camel_snake'
+require 'introspective_grape/utils/key_transformations'
+require 'active_support/hash_with_indifferent_access'
 module RequestHelpers
+
   def json
-    @json ||= JSON.parse(response.body).with_snake_keys(true)
+    @json ||= begin
+      parsed_response_body = JSON.parse(response.body)
+      case parsed_response_body
+      when Array then parsed_response_body.map { |x| snake_keys_with_indifferent_access(x) }
+      when Hash then snake_keys_with_indifferent_access(parsed_response_body)
+      else parsed_response_body
+      end
+    end
+  end
+
+  def snake_keys_with_indifferent_access(hash)
+    ActiveSupport::HashWithIndifferentAccess.new(
+      IntrospectiveGrape::Utils::KeyTransformations.snake_keys(
+        hash
+      )
+    )
   end
 
   def with_authentication(role=:superuser)
     return if @without_authentication
     current_user = User.new #double('User')
-    allow(current_user).to receive(:admin?) { true }     if role == :superuser 
+    allow(current_user).to receive(:admin?) { true }     if role == :superuser
     allow(current_user).to receive(:superuser?) { true } if role == :superuser
 
     # Stubbing API helper methods requires this very nearly undocumented invokation
     Grape::Endpoint.before_each do |endpoint|
-      allow(endpoint).to receive(:current_user) { current_user } 
+      allow(endpoint).to receive(:current_user) { current_user }
     end
   end
+
 end
 
 


### PR DESCRIPTION
 * Remove dependency on camel_snake_keys in favor of implementation
   already in activesupport
 * All specs pass
 * Move camel and snake functionality into their own utils folder so
   it can be reused throughout the gem
 * Minimize core extending by activesupport. As a gem, it should minimize side-effects in the users main application